### PR TITLE
Limits input to 9 digits

### DIFF
--- a/script.js
+++ b/script.js
@@ -19,6 +19,7 @@ createOperationEventListeners()
 allClearBtn.addEventListener('click', () => {
     setCalcDefault()
     updateDisplays()
+    scaleFontSize()
     console.log("ALL CLEARED")
 })
 
@@ -29,6 +30,7 @@ clearBtn.addEventListener('click', () => {
     }
     calc.set("equalsPressed", false)
     updateDisplays()
+    scaleFontSize()
     console.log("CLEARED")
 })
 
@@ -39,6 +41,7 @@ equalBtn.addEventListener('click', () => {
     }
     calc.set("equalsPressed", true)
     updateDisplays()
+    scaleFontSize()
     console.log("EQUALS PRESSED")
 })
 
@@ -52,6 +55,7 @@ decimalBtn.addEventListener('click', () => {
         }
     }
     updateDisplays()
+    scaleFontSize()
     console.log("DECIMAL PRESSED")
 })
 
@@ -68,6 +72,7 @@ posNegBtn.addEventListener('click', () => {
             calc.set("posNegPressed", false)
         }
     }
+    scaleFontSize()
     console.log("POSNEG PRESSED")
 })
 
@@ -112,6 +117,7 @@ function createNumberEventListeners() {
             }
             calc.set("operationPressed", false)
             updateDisplays()
+            scaleFontSize()
             console.log("NUMBER PRESSED")
             calc.forEach((key, value) => console.log(`${value}, ${key}`))
             for (let i = 0; i < 4; i++) {
@@ -197,6 +203,16 @@ function operate(operator, x, y) {
         default: return "Invalid input"
     }
     return round(output, 8)
+}
+
+function scaleFontSize() {
+    if (mainDisplay.textContent.length > 12) {
+        mainDisplay.style.fontSize = "1.75rem"
+    } else if (mainDisplay.textContent.length > 9) {
+        mainDisplay.style.fontSize = "2.5rem"
+    } else {
+        mainDisplay.style.fontSize = "2.75rem"
+    }
 }
 
 function updateDisplays() {

--- a/script.js
+++ b/script.js
@@ -87,7 +87,7 @@ function setCalcDefault() {
 function createNumberEventListeners() {
     for (let i = 0; i <= 9; i++) {
         numberBtns[i].addEventListener('click', (e) => {
-            if (calc.get("displayValue").length >= 12 && !calc.get("operationPressed")) { return }
+            if (calc.get("displayValue").length >= 9 && !calc.get("operationPressed")) { return }
             if (calc.get("displayValue") === "0" && calc.get("runningTotal") === 0 && !calc.get("posNegPressed")) {
                 calc.set("displayValue", e.target.textContent)
             } else {

--- a/style.css
+++ b/style.css
@@ -60,12 +60,13 @@ button {
 .displays {
     display: grid;
     grid-template-rows: 1fr 2fr;
-    width: 90%;
+    width: 20rem;
     padding: 1.5rem;
 }
 
 .running-total-display {
     min-width: 8rem;
+    max-width: 17rem;
     height: 2rem;
     background: grey;
     place-self: end;
@@ -76,6 +77,7 @@ button {
 
 .main-display {
     width: 100%;
+    max-width: 17rem;
     height: 4rem;
     background: darkgrey;
     margin-top: 1rem;


### PR DESCRIPTION
Limiting input to 9 digits makes it so you can't cause the display stretching just by inputting more numbers at least. Planning on adding exponential notation for anything past 999,999,999 (e.g. 1 billion would be "1e9"), which would fix display stretching on integer results past 9 digits as well.

For floats past 9 digits, I suppose before it's displayed I need to convert it to a string to check the length, and round it or truncate it if it's too long, and then convert it back to a number to display it.