### PR TITLE
Update display after pressing +/- button on negative numbers

### DIFF
--- a/script.js
+++ b/script.js
@@ -66,12 +66,12 @@ posNegBtn.addEventListener('click', () => {
         if (!calc.get("posNegPressed") && !calc.get("equalsPressed")) {
             calc.set("displayValue", "-" + calc.get("displayValue"))
             calc.set("posNegPressed", true)
-            updateDisplays()
         } else {
             calc.set("displayValue", Number(calc.get("displayValue")) * -1)
             calc.set("posNegPressed", false)
             updateDisplays()
         }
+        updateDisplays()
     }
     scaleFontSize()
     console.log("POSNEG PRESSED")


### PR DESCRIPTION
This was a simple fix. Was already changing the mapped value, just wasn't updating the display to reflect it.