### PR TITLE
Adds logic to handle if number is already negative

### DIFF
--- a/script.js
+++ b/script.js
@@ -107,7 +107,11 @@ function createNumberEventListeners() {
                         calc.set("decimalPressed", false)
                     }
                 } else if (calc.get("posNegPressed")) {
-                    calc.set("displayValue", String((Number(e.target.textContent) * -1)))
+                    if (calc.get("displayValue") === "-0") {
+                        calc.set("displayValue", String((Number(e.target.textContent) * -1)))
+                    } else {
+                        calc.set("displayValue", calc.get("displayValue") + e.target.textContent)
+                    }
                 } else if (calc.get("decimalPressed")) {
                     calc.set("displayValue", calc.get("displayValue") + e.target.textContent)
                 } else if (calc.get("displayValue") === "0") {


### PR DESCRIPTION
I realized it was only set up to take in the number pressed and make it negative, not check if the number was already negative and append to it. Now it only takes the number pressed and makes it negative if you start with 0, otherwise it will append the numbers you press to the already negative number.