### PR TITLE
Adds a check for if equals was pressed

### DIFF
--- a/script.js
+++ b/script.js
@@ -63,13 +63,14 @@ posNegBtn.addEventListener('click', () => {
     if (calc.get("operationPressed")) {
         calc.set("posNegPressed", true)
     } else {
-        if (!calc.get("posNegPressed")) {
+        if (!calc.get("posNegPressed") && !calc.get("equalsPressed")) {
             calc.set("displayValue", "-" + calc.get("displayValue"))
             calc.set("posNegPressed", true)
             updateDisplays()
         } else {
             calc.set("displayValue", Number(calc.get("displayValue")) * -1)
             calc.set("posNegPressed", false)
+            updateDisplays()
         }
     }
     scaleFontSize()


### PR DESCRIPTION
It was treating results as if they were manual inputs, in which they would only be negative if the +/- button was pressed. Adding a check that equals wasn't pressed routes it to the correct behavior of multiplying the result by -1